### PR TITLE
Add tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - published
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - if: github.event_name != 'pull_request'
+        name: Install fish using action from main branch
+        uses: fish-actions/install-fish@main
+      - if: github.event_name == 'pull_request'
+        name: Install fish using action from pull request branch
+        uses: ./.
+      - name: Check fish was installed
+        run: command -v fish >/dev/null 2>&1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - if: github.event_name != 'pull_request'
-        name: Install fish using action from master branch
-        uses: fish-actions/install-fish@master
-      - if: github.event_name == 'pull_request'
-        name: Install fish using action from pull request branch
+      - name: Install fish
         uses: ./.
       - name: Check fish was installed
         run: command -v fish >/dev/null 2>&1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: tests
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   release:
     types:
       - published
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - if: github.event_name != 'pull_request'
-        name: Install fish using action from main branch
-        uses: fish-actions/install-fish@main
+        name: Install fish using action from master branch
+        uses: fish-actions/install-fish@master
       - if: github.event_name == 'pull_request'
         name: Install fish using action from pull request branch
         uses: ./.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Install fish [![license_badge][]][license]
+# Install fish [![tests_badge][]][tests] [![license_badge][]][license]
 
 A simple action to install the latest stable release of [Fish][] on Linux or macOS.
 
 [fish]: https://fishshell.com/
 [license_badge]: https://img.shields.io/github/license/fish-actions/install-fish
 [license]: LICENSE.md
+[tests_badge]: https://github.com/fish-actions/install-fish/actions/workflows/test.yml/badge.svg
+[tests]: https://github.com/fish-actions/install-fish/actions?query=workflow%3Atests


### PR DESCRIPTION
Despite being a relatively compact action, I think it would be beneficial to test the code in this project using a workflow and to highlight the current status of any tests in the project `README.md` file with a status badge. With that in mind, this pull request introduces a small workflow for testing the action code:

* run test jobs against both `ubuntu-latest` and `macos-latest`
* triggers on pull request events, published releases, or pushes to `master` branch (using action code for corresponding branch)
* confirm presence of `fish` command in `$PATH` after installation

The tests badge added to the `README.md` file may not be visible until the workflow itself has been merged.

Here’s an [example run](https://github.com/marcransome/install-fish/actions/runs/892778313) in a forked copy of the repository.

Let me know your thoughts. 🤔 